### PR TITLE
Add TutorialSearch to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ List of free online programming/CS courses
 * [openhpi](https://openhpi.de/) - openhpi.de
 * [openuniversity](http://www.openuniversity.edu/courses/global) - openuniversity.edu/courses/global
 * [stanford online courses](http://online.stanford.edu/courses) - online.stanford.edu/courses
+* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 * [udacity](https://www.udacity.com/) - udacity.com
 * [udemy](https://www.udemy.com/courses/) - udemy.com/courses
 * [mongodb](https://university.mongodb.com/) - Free Online MongoDB Training


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Websites* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/programming-languages) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/programming-languages) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.